### PR TITLE
add ree:install task to Rakefile and drastically simplify the build process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,8 +84,6 @@ def install_gem(gem_name, version)
   name = "#{gem_name}-#{version}"
   Dir.mktmpdir("#{gem_name}-#{version}") do |tmpdir|
     Dir.chdir(tmpdir) do |dir|
-      FileUtils.rm_rf("#{tmpdir}/*")
-
       in_gem_env(tmpdir) do
         sh("unset RUBYOPT; gem install #{gem_name} --version #{version} --no-ri --no-rdoc --env-shebang")
         sh("rm #{gem_name}-#{version}.gem")

--- a/Rakefile
+++ b/Rakefile
@@ -75,8 +75,6 @@ task "ree:install", :version do |t, args|
           build_command = build_command.join(" && ")
 
           sh build_command
-
-          sh "/app/vendors/#{output}/bin/ruby -v"
       end
     end
   end


### PR DESCRIPTION
This somewhat drastically simplifies the build process for REE:

1. Builds directly into `/apps/vendors/ruby-1.8.7`.
2. Utilizes the vendored rubygems included as part of the REE tarball.
3. Gets rid of the `build_ree_command` method and inlines the functionality since it only needs to get called once.

There are a few more changes to make:

1. Upload the binary archive to S3 after build (implemented, just needs to get called).
2. Test it on a fresh dyno.